### PR TITLE
Simplify repository interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -20,8 +20,6 @@ type Event interface {
 // If history is required, this interface will allow clients to reply previous events through the server.
 // Both methods can be called from different goroutines concurrently, so you must make sure they are go-routine safe.
 type Repository interface {
-	// Gets an event based on the specified channel and event id.
-	Get(channel, id string) Event
-	// Gets the ids which should follow on from the specified channel and event id.
-	Replay(channel, id string) chan string
+	// Gets the Events which should follow on from the specified channel and event id.
+	Replay(channel, id string) chan Event
 }

--- a/repository.go
+++ b/repository.go
@@ -23,20 +23,15 @@ func (repo SliceRepository) indexOfEvent(channel, id string) int {
 	})
 }
 
-func (repo SliceRepository) Get(channel, id string) Event {
-	repo.lock.RLock()
-	defer repo.lock.RUnlock()
-	return repo.events[channel][repo.indexOfEvent(channel, id)]
-}
-
-func (repo SliceRepository) Replay(channel, id string) (ids chan string) {
-	ids = make(chan string)
+func (repo SliceRepository) Replay(channel, id string) (out chan Event) {
+	out = make(chan Event)
 	go func() {
+		defer close(out)
 		repo.lock.RLock()
 		defer repo.lock.RUnlock()
 		events := repo.events[channel][repo.indexOfEvent(channel, id):]
 		for i := range events {
-			ids <- events[i].Id()
+			out <- events[i]
 		}
 	}()
 	return

--- a/server.go
+++ b/server.go
@@ -105,8 +105,8 @@ func (srv *Server) Publish(channels []string, ev Event) {
 }
 
 func replay(repo Repository, sub *subscription) {
-	for id := range repo.Replay(sub.channel, sub.lastEventId) {
-		sub.out <- repo.Get(sub.channel, id)
+	for ev := range repo.Replay(sub.channel, sub.lastEventId) {
+		sub.out <- ev
 	}
 }
 


### PR DESCRIPTION
Hey Donny - want to check this over?
Since Replay() is now a generator which just returns a channel, it seemed like the logical step to drop Get() altogether and get Replay() to stream events rather than IDs.
