### PR TITLE
stream: make it possible to handle errors based on HTTP reponse

### DIFF
--- a/example_event_test.go
+++ b/example_event_test.go
@@ -39,7 +39,7 @@ func ExampleEvent() {
 	http.HandleFunc("/time", srv.Handler("time"))
 	go http.Serve(l, nil)
 	go TimePublisher(srv)
-	stream, err := eventsource.Subscribe("http://127.0.0.1:8080/time", "")
+	stream, _, err := eventsource.Subscribe("http://127.0.0.1:8080/time", "")
 	if err != nil {
 		return
 	}

--- a/example_repository_test.go
+++ b/example_repository_test.go
@@ -42,7 +42,7 @@ func ExampleRepository() {
 	}
 	defer l.Close()
 	go http.Serve(l, nil)
-	stream, err := eventsource.Subscribe("http://127.0.0.1:8080/articles", "")
+	stream, _, err := eventsource.Subscribe("http://127.0.0.1:8080/articles", "")
 	if err != nil {
 		return
 	}
@@ -52,7 +52,7 @@ func ExampleRepository() {
 		ev := <-stream.Events
 		fmt.Println(ev.Id(), ev.Event(), ev.Data())
 	}
-	stream, err = eventsource.Subscribe("http://127.0.0.1:8080/articles", "1")
+	stream, _, err = eventsource.Subscribe("http://127.0.0.1:8080/articles", "1")
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/stream.go
+++ b/stream.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+	"io/ioutil"
+	"fmt"
 )
 
 // Stream handles a connection for receiving Server Sent Events.
@@ -15,7 +17,6 @@ type Stream struct {
 	url         string
 	lastEventId string
 	retry       time.Duration
-	response    *http.Response
 	// Events emits the events received by the stream
 	Events chan Event
 	// Errors emits any errors encountered while reading events from the stream.
@@ -25,9 +26,19 @@ type Stream struct {
 	Errors chan error
 }
 
+type SubscriptionError struct {
+	Code int
+	Message string
+}
+
+func (e SubscriptionError) String() string{
+    return fmt.Sprintf("%d: %s",e.Code,e.Message)
+}
+
 // Subscribe to the Events emitted from the specified url.
 // If lastEventId is non-empty it will be sent to the server in case it can replay missed events.
-func Subscribe(url, lastEventId string) (*Stream, error) {
+func Subscribe(url, lastEventId string) (*Stream, SubscriptionError, error) {
+	var subscriptionError SubscriptionError
 	stream := &Stream{
 		url:         url,
 		lastEventId: lastEventId,
@@ -35,20 +46,26 @@ func Subscribe(url, lastEventId string) (*Stream, error) {
 		Events:      make(chan Event),
 		Errors:      make(chan error),
 	}
-	r, err := stream.connect()
+	r, resp, err := stream.connect()
 	if err != nil {
-		return nil, err
+		return nil, subscriptionError, err
 	}
+
+	if resp.StatusCode != 200 {
+		message, err := ioutil.ReadAll(resp.Body)
+		subscriptionError = SubscriptionError{
+			Code: resp.StatusCode,
+			Message: string(message),
+		}
+
+		return stream, subscriptionError, err
+	}
+
 	go stream.stream(r)
-	return stream, nil
+	return stream, subscriptionError, nil
 }
 
-func (stream *Stream) HttpResponse() *http.Response {
-	return stream.response
-}
-
-func (stream *Stream) connect() (r io.ReadCloser, err error) {
-	var resp *http.Response
+func (stream *Stream) connect() (r io.ReadCloser, resp *http.Response, err error) {
 	var req *http.Request
 	if req, err = http.NewRequest("GET", stream.url, nil); err != nil {
 		return
@@ -61,7 +78,6 @@ func (stream *Stream) connect() (r io.ReadCloser, err error) {
 	if resp, err = stream.c.Do(req); err != nil {
 		return
 	}
-	stream.response = resp
 	r = resp.Body
 	return
 }
@@ -94,7 +110,7 @@ func (stream *Stream) stream(r io.ReadCloser) {
 		// NOTE: because of the defer we're opening the new connection
 		// before closing the old one. Shouldn't be a problem in practice,
 		// but something to be aware of.
-		next, err := stream.connect()
+		next, _, err := stream.connect()
 		if err == nil {
 			go stream.stream(next)
 			break

--- a/stream_test.go
+++ b/stream_test.go
@@ -19,16 +19,15 @@ func TestStreamErrorHandling(t *testing.T) {
 	go http.Serve(listener, nil)
 
 	// this is error handling example
-	stream, err := Subscribe("http://127.0.0.1:8080/stream", "")
+	_, subscriptionError, err := Subscribe("http://127.0.0.1:8080/stream", "")
 
 	if err != nil {
 		t.Error("failed to subscribe")
 	}
 
-	if stream.HttpResponse().StatusCode == 500 {
-		// you can handle error as you like based on status code
+	if subscriptionError.String() == "500: Something wrong.\n" {
 		return
+	} else {
+		t.Error(`Error string should be "500: Something wrong."`)
 	}
-
-	t.Error("HTTP respoonse should be 500")
 }


### PR DESCRIPTION
This is an example of error handling base on HTTP status code:

``` go
stream, err := eventsource.Subscribe("http://127.0.0.1:8080/stream", "")

if err != nil {
  return
}

if stream.HttpResponse().StatusCode == 500 {
  // you can handle error as you like based on status code
}
```
