### PR TITLE
stream: make it possible to handle errors based on HTTP response

### DIFF
--- a/example_error_handling_stream_test.go
+++ b/example_error_handling_stream_test.go
@@ -1,0 +1,34 @@
+package eventsource_test
+
+import (
+	"fmt"
+	"github.com/donovanhide/eventsource"
+	"net"
+	"net/http"
+)
+
+func ExampleErrorHandlingStream() {
+	listener, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		return
+	}
+	defer listener.Close()
+	http.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Something wrong.", 500)
+	})
+	go http.Serve(listener, nil)
+
+	_, err = eventsource.Subscribe("http://127.0.0.1:8080/stream", "")
+	if err != nil {
+		if serr, ok := err.(eventsource.SubscriptionError); ok {
+			fmt.Printf("Status code: %d\n", serr.Code)
+			fmt.Printf("Message: %s\n", serr.Message)
+		} else {
+			fmt.Println("failed to subscribe")
+		}
+	}
+
+	// Output:
+	// Status code: 500
+	// Message: Something wrong.
+}


### PR DESCRIPTION
This is a pull request to make `Subscribe` possible to handle errors based on HTTP response.

This is the example code to handle errors:

``` go
_, err = eventsource.Subscribe("http://127.0.0.1:8080/stream", "")
if err != nil {
  if serr, ok := err.(eventsource.SubscriptionError); ok {
    fmt.Printf("Status code: %d\n", serr.Code)
    fmt.Printf("Message: %s\n", serr.Message)
  } else {
    fmt.Println("failed to subscribe")
  }
}

// Output:
// Status code: 500
// Message: Something wrong.
```

I have sent the other PR about this feature as [#7](https://github.com/donovanhide/eventsource/pull/7) a few days ago, but that's approach was different from this and that contains unnecessary commits. So now I send this as another PR :-)
