### PR TITLE
Stream.Close

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,44 @@
+package eventsource
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStreamClose(t *testing.T) {
+	server := NewServer()
+	defer server.Close()
+
+	httpServer := httptest.NewServer(server.Handler("TestStreamClose"))
+	defer httpServer.Close()
+
+	stream, err := Subscribe(httpServer.URL, "")
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %s", err)
+	}
+
+	stream.Close()
+
+	if !stream.Closed() {
+		t.Errorf("Expected stream.Closed() to be true. Got false")
+	}
+
+	select {
+	case _, ok := <-stream.Events:
+		if ok {
+			t.Errorf("Expected stream.Events channel to be closed. Is still open.")
+		}
+	case <-time.After(time.Second):
+		t.Errorf("Timed out waiting for stream.Events channel to close")
+	}
+
+	select {
+	case _, ok := <-stream.Errors:
+		if ok {
+			t.Errorf("Expected stream.Errors channel to be closed. Is still open.")
+		}
+	case <-time.After(time.Second):
+		t.Errorf("Timed out waiting for stream.Errors channel to close")
+	}
+}


### PR DESCRIPTION
This adds `Stream.Close()` which will shut down a stream and prevent it from trying to read any further events from the server.

I also added another related change to not block trying to write to the `Stream.Errors` channel (would happen if nobody was reading from it). Now the stream will buffer a single error, and if it's not pulled off the channel, further errors will be dropped.
I went with this as it was the simplest. But perhaps a more useful solution would be a way to discard the older error so if the consumer does pull it off, the consumer gets the most recent one. Can either read from the channel and put the new one on, or use a `stream.Error()` func which returns a mutex-protected struct attribute.

Resolves #6