### PR TITLE
Make Encoder public

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -24,7 +24,7 @@ var encoderTests = []struct {
 func TestRoundTrip(t *testing.T) {
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf, false)
-	dec := newDecoder(buf)
+	dec := NewDecoder(buf)
 	for _, tt := range encoderTests {
 		want := tt.event
 		if err := enc.Encode(want); err != nil {

--- a/codec_test.go
+++ b/codec_test.go
@@ -23,7 +23,7 @@ var encoderTests = []struct {
 
 func TestRoundTrip(t *testing.T) {
 	buf := new(bytes.Buffer)
-	enc := newEncoder(buf, false)
+	enc := NewEncoder(buf, false)
 	dec := newDecoder(buf)
 	for _, tt := range encoderTests {
 		want := tt.event

--- a/decoder.go
+++ b/decoder.go
@@ -17,12 +17,12 @@ func (s *publication) Event() string { return s.event }
 func (s *publication) Data() string  { return s.data }
 func (s *publication) Retry() int64  { return s.retry }
 
-type decoder struct {
+type Decoder struct {
 	*bufio.Reader
 }
 
-func newDecoder(r io.Reader) *decoder {
-	dec := &decoder{bufio.NewReader(newNormaliser(r))}
+func NewDecoder(r io.Reader) *Decoder {
+	dec := &Decoder{bufio.NewReader(newNormaliser(r))}
 	return dec
 }
 
@@ -31,7 +31,7 @@ func newDecoder(r io.Reader) *decoder {
 // Graceful disconnects (between events) are indicated by an io.EOF error.
 // Any error occuring mid-event is considered non-graceful and will
 // show up as some other error (most likely io.ErrUnexpectedEOF).
-func (dec *decoder) Decode() (Event, error) {
+func (dec *Decoder) Decode() (Event, error) {
 
 	// peek ahead before we start a new event so we can return EOFs
 	_, err := dec.Peek(1)

--- a/decoder.go
+++ b/decoder.go
@@ -17,10 +17,13 @@ func (s *publication) Event() string { return s.event }
 func (s *publication) Data() string  { return s.data }
 func (s *publication) Retry() int64  { return s.retry }
 
+// A Decoder is capable of reading Events from a stream.
 type Decoder struct {
 	*bufio.Reader
 }
 
+// NewDecoder returns a new Decoder instance that reads events
+// with the given io.Reader.
 func NewDecoder(r io.Reader) *Decoder {
 	dec := &Decoder{bufio.NewReader(newNormaliser(r))}
 	return dec

--- a/encoder.go
+++ b/encoder.go
@@ -18,19 +18,19 @@ var (
 	}
 )
 
-type encoder struct {
+type Encoder struct {
 	w          io.Writer
 	compressed bool
 }
 
-func newEncoder(w io.Writer, compressed bool) *encoder {
+func NewEncoder(w io.Writer, compressed bool) *Encoder {
 	if compressed {
-		return &encoder{w: gzip.NewWriter(w), compressed: true}
+		return &Encoder{w: gzip.NewWriter(w), compressed: true}
 	}
-	return &encoder{w: w}
+	return &Encoder{w: w}
 }
 
-func (enc *encoder) Encode(ev Event) error {
+func (enc *Encoder) Encode(ev Event) error {
 	for _, field := range encFields {
 		prefix, value := field.prefix, field.value(ev)
 		if len(value) == 0 {

--- a/encoder.go
+++ b/encoder.go
@@ -18,11 +18,16 @@ var (
 	}
 )
 
+// An Encoder is capable of writing Events to a stream. Optionally
+// Events can be gzip compressed in this process.
 type Encoder struct {
 	w          io.Writer
 	compressed bool
 }
 
+// NewEncoder returns an Encoder for a given io.Writer.
+// When compressed is set to true, a gzip writer will be
+// created.
 func NewEncoder(w io.Writer, compressed bool) *Encoder {
 	if compressed {
 		return &Encoder{w: gzip.NewWriter(w), compressed: true}
@@ -30,6 +35,8 @@ func NewEncoder(w io.Writer, compressed bool) *Encoder {
 	return &Encoder{w: w}
 }
 
+// Encode writes an event in the format specified by the
+// server-sent events protocol.
 func (enc *Encoder) Encode(ev Event) error {
 	for _, field := range encFields {
 		prefix, value := field.prefix, field.value(ev)

--- a/server.go
+++ b/server.go
@@ -76,7 +76,7 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 		flusher := w.(http.Flusher)
 		notifier := w.(http.CloseNotifier)
 		flusher.Flush()
-		enc := newEncoder(w, useGzip)
+		enc := NewEncoder(w, useGzip)
 		for {
 			select {
 			case <-notifier.CloseNotify():

--- a/stream.go
+++ b/stream.go
@@ -105,7 +105,7 @@ func (stream *Stream) connect() (r io.ReadCloser, err error) {
 
 func (stream *Stream) stream(r io.ReadCloser) {
 	defer r.Close()
-	dec := newDecoder(r)
+	dec := NewDecoder(r)
 	for {
 		ev, err := dec.Decode()
 


### PR DESCRIPTION
In order to allow users to reuse the encoding functionality outside of
the eventsource package.

My use case is that I want to allow clients to request the number of historical
log messages that are replayed to them before the live stream starts. This is 
currently not possible with the Repository interface because you can't configure
this number. I thought about implementing a Repository that forgets old logs and 
limits the replay like this. Still, the number could not depend on the client's 
request.

In order to solve my use case, I want to use this library's encoder to write the
historical log messages to the HTTP response before using the regular eventsource 
server to stream new (live) messages.