### PR TITLE
http client override

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -14,7 +14,7 @@ import (
 // It will try and reconnect if the connection is lost, respecting both
 // received retry delays and event id's.
 type Stream struct {
-	c           http.Client
+	c           *http.Client
 	req         *http.Request
 	lastEventId string
 	retry       time.Duration
@@ -50,9 +50,16 @@ func Subscribe(url, lastEventId string) (*Stream, error) {
 
 // SubscribeWithRequest will take an http.Request to setup the stream, allowing custom headers
 // to be specified, authentication to be configured, etc.
-func SubscribeWithRequest(lastEventId string, req *http.Request) (*Stream, error) {
+func SubscribeWithRequest(lastEventId string, request *http.Request) (*Stream, error) {
+	return SubscribeWith(lastEventId, http.DefaultClient, request)
+}
+
+// SubscribeWith takes a http client and request providing customization over both headers and
+// control over the http client settings (timeouts, tls, etc)
+func SubscribeWith(lastEventId string, client *http.Client, request *http.Request) (*Stream, error) {
 	stream := &Stream{
-		req:         req,
+		c:           client,
+		req:         request,
 		lastEventId: lastEventId,
 		retry:       (time.Millisecond * 3000),
 		Events:      make(chan Event),


### PR DESCRIPTION
adding a SubscribeWith method, permitting the consumer to override both the request and the http.Client (useful for TLS settings for example)