### PR TITLE
add subscribe with timeout

### DIFF
--- a/example_error_handling_during_stream_test.go
+++ b/example_error_handling_during_stream_test.go
@@ -1,0 +1,49 @@
+package eventsource
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func eventsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	flusher := w.(http.Flusher)
+	k := 0
+	for {
+		if k >= 10 {
+			break // enable httptestserver to close the current connection
+		}
+		fmt.Fprint(w, "event: test\n")
+		fmt.Fprintf(w, "%s\n\n", "test")
+		flusher.Flush()
+		k += 1
+	}
+
+}
+
+func TestErrorDuringStream(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(eventsHandler))
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	stream, _ := SubscribeWithTimeout("", http.DefaultClient, req, time.Second)
+	ts.Close()
+	closed := false
+eventLoop:
+	for {
+		select {
+		case _, ok := <-stream.ErrorsWithTimeout:
+			if !ok {
+				closed = true
+				break eventLoop
+			}
+		case _ = <-stream.EventsWithTimeout:
+		}
+	}
+	if !closed {
+		t.Errorf("The Events are not closed")
+	}
+}


### PR DESCRIPTION
In some cases, it might take long time or forever to recover a failed server. Application side should be able to configure some timeout and deal with the error. 

With this PR, the client is able to detect the timeout when the `ErrorsWithTimeout` or `ErrorsWithTimeout` are closed. 

The changes are compatible with all the applications which are using this library. 