### PR TITLE
add possibility to Close() a stream

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -27,6 +28,10 @@ type Stream struct {
 	Errors chan error
 	// Logger is a logger that, when set, will be used for logging debug messages
 	Logger *log.Logger
+	// isClosed is a marker that the stream is/should be closed
+	isClosed bool
+	// isClosedMutex is a mutex protecting concurrent read/write access of isClosed
+	isClosedMutex sync.RWMutex
 }
 
 type SubscriptionError struct {
@@ -61,7 +66,7 @@ func SubscribeWith(lastEventId string, client *http.Client, request *http.Reques
 		c:           client,
 		req:         request,
 		lastEventId: lastEventId,
-		retry:       (time.Millisecond * 3000),
+		retry:       time.Millisecond * 3000,
 		Events:      make(chan Event),
 		Errors:      make(chan error),
 	}
@@ -73,6 +78,29 @@ func SubscribeWith(lastEventId string, client *http.Client, request *http.Reques
 	}
 	go stream.stream(r)
 	return stream, nil
+}
+
+// Close will close the stream. It is safe for concurrent access.
+func (stream *Stream) Close() {
+	if stream.isStreamClosed() {
+		return
+	}
+
+	stream.markStreamClosed()
+	close(stream.Errors)
+	close(stream.Events)
+}
+
+func (stream *Stream) isStreamClosed() bool {
+	stream.isClosedMutex.RLock()
+	defer stream.isClosedMutex.RUnlock()
+	return stream.isClosed
+}
+
+func (stream *Stream) markStreamClosed() {
+	stream.isClosedMutex.Lock()
+	defer stream.isClosedMutex.Unlock()
+	stream.isClosed = true
 }
 
 // Go's http package doesn't copy headers across when it encounters
@@ -112,15 +140,27 @@ func (stream *Stream) connect() (r io.ReadCloser, err error) {
 
 func (stream *Stream) stream(r io.ReadCloser) {
 	defer r.Close()
+
+	// receives events until an error is encountered
+	stream.receiveEvents(r)
+
+	// tries to reconnect and start the stream again
+	stream.retryRestartStream()
+}
+
+func (stream *Stream) receiveEvents(r io.ReadCloser) {
 	dec := NewDecoder(r)
+
 	for {
 		ev, err := dec.Decode()
-
+		if stream.isStreamClosed() {
+			return
+		}
 		if err != nil {
 			stream.Errors <- err
-			// respond to all errors by reconnecting and trying again
-			break
+			return
 		}
+
 		pub := ev.(*publication)
 		if pub.Retry() > 0 {
 			stream.retry = time.Duration(pub.Retry()) * time.Millisecond
@@ -130,20 +170,25 @@ func (stream *Stream) stream(r io.ReadCloser) {
 		}
 		stream.Events <- ev
 	}
+}
+
+func (stream *Stream) retryRestartStream() {
 	backoff := stream.retry
 	for {
-		time.Sleep(backoff)
 		if stream.Logger != nil {
 			stream.Logger.Printf("Reconnecting in %0.4f secs\n", backoff.Seconds())
 		}
-
+		time.Sleep(backoff)
+		if stream.isStreamClosed() {
+			return
+		}
 		// NOTE: because of the defer we're opening the new connection
 		// before closing the old one. Shouldn't be a problem in practice,
 		// but something to be aware of.
-		next, err := stream.connect()
+		r, err := stream.connect()
 		if err == nil {
-			go stream.stream(next)
-			break
+			go stream.stream(r)
+			return
 		}
 		stream.Errors <- err
 		backoff *= 2

--- a/stream.go
+++ b/stream.go
@@ -80,7 +80,7 @@ func SubscribeWith(lastEventId string, client *http.Client, request *http.Reques
 	return stream, nil
 }
 
-// Close will close the stream. It is safe for concurrent access.
+// Close will close the stream. It is safe for concurrent access and can be called multiple times.
 func (stream *Stream) Close() {
 	if stream.isStreamClosed() {
 		return

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,97 @@
+package eventsource
+
+import (
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+const (
+	eventChannelName   = "Test"
+	timeToWaitForEvent = 100 * time.Millisecond
+)
+
+func TestStreamSubscribeEventsChan(t *testing.T) {
+	server := NewServer()
+	httpServer := httptest.NewServer(server.Handler(eventChannelName))
+	// The server has to be closed before the httpServer is closed.
+	// Otherwise the httpServer has still an open connection and it can not close.
+	defer httpServer.Close()
+	defer server.Close()
+
+	stream := mustSubscribe(httpServer.URL, "")
+
+	publishedEvent := &publication{id: "123"}
+	server.Publish([]string{eventChannelName}, publishedEvent)
+
+	select {
+	case receivedEvent := <-stream.Events:
+		if !reflect.DeepEqual(receivedEvent, publishedEvent) {
+			t.Errorf("got event %+v, want %+v", receivedEvent, publishedEvent)
+		}
+	case <-time.After(timeToWaitForEvent):
+		t.Error("Timed out waiting for event")
+	}
+}
+
+func TestStreamSubscribeErrorsChan(t *testing.T) {
+	server := NewServer()
+	httpServer := httptest.NewServer(server.Handler(eventChannelName))
+
+	defer httpServer.Close()
+
+	stream := mustSubscribe(httpServer.URL, "")
+	server.Close()
+
+	select {
+	case err := <-stream.Errors:
+		if err != io.EOF {
+			t.Errorf("got error %+v, want %+v", err, io.EOF)
+		}
+	case <-time.After(timeToWaitForEvent):
+		t.Error("Timed out waiting for error event")
+	}
+}
+
+func TestStreamClose(t *testing.T) {
+	server := NewServer()
+	httpServer := httptest.NewServer(server.Handler(eventChannelName))
+	// The server has to be closed before the httpServer is closed.
+	// Otherwise the httpServer has still an open connection and it can not close.
+	defer httpServer.Close()
+	defer server.Close()
+
+	stream := mustSubscribe(httpServer.URL, "")
+	stream.Close()
+	// its safe to Close the stream multiple times
+	stream.Close()
+
+	select {
+	case _, ok := <-stream.Events:
+		if ok {
+			t.Error("Expected stream.Events channel to be closed. Is still open.")
+		}
+	case <-time.After(timeToWaitForEvent):
+		t.Error("Timed out waiting for stream.Events channel to close")
+	}
+
+	select {
+	case _, ok := <-stream.Errors:
+		if ok {
+			t.Error("Expected stream.Errors channel to be closed. Is still open.")
+		}
+	case <-time.After(timeToWaitForEvent):
+		t.Error("Timed out waiting for stream.Errors channel to close")
+	}
+}
+
+func mustSubscribe(url, lastEventId string) *Stream {
+	stream, err := Subscribe(url, lastEventId)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to subscribe: %s", err))
+	}
+	return stream
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,7 +1,6 @@
 package eventsource
 
 import (
-	"fmt"
 	"io"
 	"net/http/httptest"
 	"reflect"
@@ -22,7 +21,7 @@ func TestStreamSubscribeEventsChan(t *testing.T) {
 	defer httpServer.Close()
 	defer server.Close()
 
-	stream := mustSubscribe(httpServer.URL, "")
+	stream := mustSubscribe(t, httpServer.URL, "")
 
 	publishedEvent := &publication{id: "123"}
 	server.Publish([]string{eventChannelName}, publishedEvent)
@@ -43,7 +42,7 @@ func TestStreamSubscribeErrorsChan(t *testing.T) {
 
 	defer httpServer.Close()
 
-	stream := mustSubscribe(httpServer.URL, "")
+	stream := mustSubscribe(t, httpServer.URL, "")
 	server.Close()
 
 	select {
@@ -64,7 +63,7 @@ func TestStreamClose(t *testing.T) {
 	defer httpServer.Close()
 	defer server.Close()
 
-	stream := mustSubscribe(httpServer.URL, "")
+	stream := mustSubscribe(t, httpServer.URL, "")
 	stream.Close()
 	// its safe to Close the stream multiple times
 	stream.Close()
@@ -88,10 +87,10 @@ func TestStreamClose(t *testing.T) {
 	}
 }
 
-func mustSubscribe(url, lastEventId string) *Stream {
+func mustSubscribe(t *testing.T, url, lastEventId string) *Stream {
 	stream, err := Subscribe(url, lastEventId)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to subscribe: %s", err))
+		t.Fatalf("Failed to subscribe: %s", err)
 	}
 	return stream
 }


### PR DESCRIPTION
This PR tries to solve #6. 

@donovanhide it is yet another implementation, but I let myself guide by the tests that I implemented and it was the most simple solution I was able to come up with, enabling concurrent and multiple access of the `Close()` method. Let me know what you think about it. 

I am working on the go-marathon project to enable a failover of the current connected member, which is done by the help of this neat library, to other members in the Marathon cluster and it looks like with this Close method it works.