### PR TITLE
fix blocking in server http.Handler when server is closed

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 type subscription struct {
@@ -32,6 +33,8 @@ type Server struct {
 	subs          chan *subscription
 	unregister    chan *subscription
 	quit          chan bool
+	isClosed      bool
+	isClosedMutex sync.RWMutex
 }
 
 // Create a new Server ready for handler creation and publishing events
@@ -51,6 +54,7 @@ func NewServer() *Server {
 // Stop handling publishing
 func (srv *Server) Close() {
 	srv.quit <- true
+	srv.markServerClosed()
 }
 
 // Create a new handler for serving a specified channel
@@ -68,6 +72,12 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 			h.Set("Content-Encoding", "gzip")
 		}
 		w.WriteHeader(http.StatusOK)
+
+		// If the Handler is still active even though the server is closed, stop here.
+		// Otherwise the Handler will block while publishing to srv.subs indefinitely.
+		if srv.isServerClosed() {
+			return
+		}
 
 		sub := &subscription{
 			channel:     channel,
@@ -164,4 +174,16 @@ func (srv *Server) run() {
 			return
 		}
 	}
+}
+
+func (srv *Server) isServerClosed() bool {
+	srv.isClosedMutex.RLock()
+	defer srv.isClosedMutex.RUnlock()
+	return srv.isClosed
+}
+
+func (srv *Server) markServerClosed() {
+	srv.isClosedMutex.Lock()
+	defer srv.isClosedMutex.Unlock()
+	srv.isClosed = true
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,34 @@
+package eventsource
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
+	server := NewServer()
+	httpServer := httptest.NewServer(server.Handler("test"))
+	defer httpServer.Close()
+
+	server.Close()
+	responses := make(chan *http.Response)
+
+	go func() {
+		resp, err := http.Get(httpServer.URL)
+		if err != nil {
+			t.Fatalf("Unexpected error %s", err)
+		}
+		responses <- resp
+	}()
+
+	select {
+	case resp := <-responses:
+		if resp.StatusCode != 200 {
+			t.Errorf("Received StatusCode %d, want 200", resp.StatusCode)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Errorf("Did not receive response in time")
+	}
+}


### PR DESCRIPTION
Hi @donovanhide, 

while working with the event source library I found a problem that happens when making requests to the event server, even though the event server was already closed. The handler tries to publish to `srv.subs <- sub`, which will block endlessly. I provided a test case for this. 

As a side note, I was first trying to implement the quit signal to the Handler with another channel, but found this to be difficult, because the `Handler` may be called multiple times and therefore some multiplexing on that channel would be required. Therefore I went for a similar mutex solution as in the stream.

I am by the way not sure what to respond from the Handler in case the server is closed. I went with the same 200 response with basically an empty body now, what do you think about this?