### PR TITLE
dont publish empty events when only \n is received

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,6 +1,7 @@
 package eventsource
 
 import (
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -8,29 +9,39 @@ import (
 
 func TestDecode(t *testing.T) {
 	tests := []struct {
-		rawInput    string
-		wantedEvent *publication
+		rawInput     string
+		wantedEvents []*publication
 	}{
 		{
-			rawInput:    "event: eventName\ndata: {\"sample\":\"value\"}\n\n",
-			wantedEvent: &publication{event: "eventName", data: "{\"sample\":\"value\"}"},
+			rawInput:     "event: eventName\ndata: {\"sample\":\"value\"}\n\n",
+			wantedEvents: []*publication{{event: "eventName", data: "{\"sample\":\"value\"}"}},
 		},
 		{
 			// the newlines should not be parsed as empty event
-			rawInput:    "\n\n\nevent: eventName\n\n",
-			wantedEvent: &publication{event: "eventName"},
+			rawInput:     "\n\n\nevent: event1\n\n\n\n\nevent: event2\n\n",
+			wantedEvents: []*publication{{event: "event1"}, {event: "event2"}},
 		},
 	}
 
 	for _, test := range tests {
 		decoder := NewDecoder(strings.NewReader(test.rawInput))
-		event, err := decoder.Decode()
-		if err != nil {
-			t.Fatalf("Unexpected error on decoding event: %s", err)
-		}
+		i := 0
+		for {
+			event, err := decoder.Decode()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error on decoding event: %s", err)
+			}
 
-		if !reflect.DeepEqual(event, test.wantedEvent) {
-			t.Errorf("Parsed event %+v does not equal wanted event %+v", event, test.wantedEvent)
+			if !reflect.DeepEqual(event, test.wantedEvents[i]) {
+				t.Fatalf("Parsed event %+v does not equal wanted event %+v", event, test.wantedEvents[i])
+			}
+			i++
+		}
+		if i != len(test.wantedEvents) {
+			t.Fatalf("Unexpected number of events: %d does not equal wanted: %d", i, len(test.wantedEvents))
 		}
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,0 +1,36 @@
+package eventsource
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		rawInput    string
+		wantedEvent *publication
+	}{
+		{
+			rawInput:    "event: eventName\ndata: {\"sample\":\"value\"}\n\n",
+			wantedEvent: &publication{event: "eventName", data: "{\"sample\":\"value\"}"},
+		},
+		{
+			// the newlines should not be parsed as empty event
+			rawInput:    "\n\n\nevent: eventName\n\n",
+			wantedEvent: &publication{event: "eventName"},
+		},
+	}
+
+	for _, test := range tests {
+		decoder := NewDecoder(strings.NewReader(test.rawInput))
+		event, err := decoder.Decode()
+		if err != nil {
+			t.Fatalf("Unexpected error on decoding event: %s", err)
+		}
+
+		if !reflect.DeepEqual(event, test.wantedEvent) {
+			t.Errorf("Parsed event %+v does not equal wanted event %+v", event, test.wantedEvent)
+		}
+	}
+}


### PR DESCRIPTION
Hi @donovanhide,

while using the `eventsource` library in the upstream library `go-marathon` I realised that it is publishing empty events, given it receives only a new line `\n` from the server. Marathon does this about all 10 seconds, in order to keep the underlying connection alive (so my guess). I had a look at the code and saw that we can easily fix this behaviour by replacing the `break` with a `continue` statement. For us this is more to tidy a bit up, it is not producing any real errors in `go-marathon`, but it produces a lot of logs that the event could not be parsed.