### PR TITLE
Prevent panics by closing channels on unregister

### DIFF
--- a/server.go
+++ b/server.go
@@ -142,13 +142,14 @@ func (srv *Server) run() {
 			repos[reg.channel] = reg.repository
 		case sub := <-srv.unregister:
 			delete(subs[sub.channel], sub)
+			close(sub.out)
 		case pub := <-srv.pub:
 			for _, c := range pub.channels {
 				for s := range subs[c] {
 					select {
 					case s.out <- pub.event:
 					default:
-						srv.unregister <- s
+						delete(subs[s.channel], s)
 						close(s.out)
 					}
 


### PR DESCRIPTION
There is a possibility of writing to a closed channel in the code. 

The select block chooses a case at random when multiple cases are ready. There is a possible race in the code where `case pub := <-srv.pub:` is chosen over `case sub := <-srv.unregister:` and as a result, writing to the closed channel.