### PR TITLE
fix go vet and test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  post:
+    - go vet ./...

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,4 @@
 test:
   post:
     - go vet ./...
+

--- a/normalise_test.go
+++ b/normalise_test.go
@@ -15,7 +15,7 @@ var (
 	expected     = []string{"line1", "line2", "line3"}
 )
 
-func Testnormaliser(t *testing.T) {
+func TestNormaliser(t *testing.T) {
 	for i, first := range endings {
 		for j, second := range endings {
 			for k, suffix := range suffixes {

--- a/repository.go
+++ b/repository.go
@@ -17,13 +17,13 @@ func NewSliceRepository() *SliceRepository {
 	}
 }
 
-func (repo SliceRepository) indexOfEvent(channel, id string) int {
+func (repo *SliceRepository) indexOfEvent(channel, id string) int {
 	return sort.Search(len(repo.events[channel]), func(i int) bool {
 		return repo.events[channel][i].Id() >= id
 	})
 }
 
-func (repo SliceRepository) Replay(channel, id string) (out chan Event) {
+func (repo *SliceRepository) Replay(channel, id string) (out chan Event) {
 	out = make(chan Event)
 	go func() {
 		defer close(out)

--- a/stream.go
+++ b/stream.go
@@ -53,10 +53,14 @@ func Subscribe(url, lastEventId string) (*Stream, error) {
 	return SubscribeWithRequest(lastEventId, req)
 }
 
+var redirectingClient = &http.Client{
+	CheckRedirect: checkRedirect,
+}
+
 // SubscribeWithRequest will take an http.Request to setup the stream, allowing custom headers
 // to be specified, authentication to be configured, etc.
 func SubscribeWithRequest(lastEventId string, request *http.Request) (*Stream, error) {
-	return SubscribeWith(lastEventId, http.DefaultClient, request)
+	return SubscribeWith(lastEventId, redirectingClient, request)
 }
 
 // SubscribeWith takes a http client and request providing customization over both headers and
@@ -70,7 +74,6 @@ func SubscribeWith(lastEventId string, client *http.Client, request *http.Reques
 		Events:      make(chan Event),
 		Errors:      make(chan error),
 	}
-	stream.c.CheckRedirect = checkRedirect
 
 	r, err := stream.connect()
 	if err != nil {


### PR DESCRIPTION
Here are a few fixes to satisfy go vet and test.  I'm running these on circleci.  We use them regularly and it might be worth enabling them for this repo (maybe even adding a badge).  There is also travis if you'd prefer that.  You can see the failures this fixes at:

https://circleci.com/gh/launchdarkly/eventsource/19