### PR TITLE
Create LICENCE

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,13 @@
+Copyright 2021 eventsource authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Currently the godoc links on this repo are not working because it can not detect a license.

https://pkg.go.dev/github.com/donovanhide/eventsource

This should fix that problem.